### PR TITLE
Define plugin instance on load

### DIFF
--- a/src/refaltor/vote/Main.php
+++ b/src/refaltor/vote/Main.php
@@ -8,10 +8,14 @@ use refaltor\vote\command\vote;
 class Main extends PluginBase
 {
     private static self $instance;
+    
+    public function onLoad()
+    {
+        self::$instance = $this;
+    }
 
     public function onEnable()
     {
-        self::$instance = $this;
         $this->saveResource('config.yml');
         $array = $this->getConfig()->get('command');
         $this->getServer()->getCommandMap()->register($array['usage'], new vote($this));


### PR DESCRIPTION
If a plugin depends on voteReward, but it loads before voteReward (When a plugin has `load: STARTUP` in its plugin.yml, it will load before all the depended plugins), errors will occur when it uses `Main::getInstance()`.